### PR TITLE
Update base.py

### DIFF
--- a/lhotse/features/base.py
+++ b/lhotse/features/base.py
@@ -286,7 +286,7 @@ class FeatureExtractor(metaclass=ABCMeta):
             channels=channels if channels is not None else recording.channel_ids,
             # The start is relative to the beginning of the recording.
             start=offset,
-            duration=recording.duration,
+            duration=recording.duration if duration is not None else recording.duration,
             type=self.name,
             num_frames=feats.shape[0],
             num_features=feats.shape[1],


### PR DESCRIPTION
I think it should be fine, because with the previous line this assert was activated, now it's not the case anymore

    assert expected_num_frames == f.num_frames, (
        f"Features: manifest is inconsistent: declared num_frames is {f.num_frames}, "
        f"but duration ({f.duration}s) / frame_shift ({f.frame_shift}s) results in {expected_num_frames} frames. "
        f"If you're using a custom feature extractor, you might need to ensure that it preserves "
        f"this relationship between duration, frame_shift and num_frames (use rounding up if needed - "
        f"see lhotse.utils.compute_num_frames)."
    )